### PR TITLE
Sets the one to may relationship name

### DIFF
--- a/src/util/define_relationships.js
+++ b/src/util/define_relationships.js
@@ -10,8 +10,9 @@ const oneToOne = ({ model, reference, rel }) => {
 };
 
 const oneToMany = ({ model, reference, rel }) => {
-  model.hasMany(reference, { foreignKey: rel.as, sourceKey: rel.from });
-  reference.belongsTo(model, { foreignKey: rel.as, targetKey: rel.from });
+  const foreignKey = rel.as ? `${rel.as}Id` : undefined;
+  model.hasMany(reference, { as: rel.as, foreignKey, sourceKey: rel.from });
+  reference.belongsTo(model, { as: rel.as, foreignKey, targetKey: rel.from });
 };
 
 const manyToMany = ({ sequelize, model, reference, rel, models }) => {


### PR DESCRIPTION
Sets the relationship name as what we can use to refer to the
relationship as.  Without this there is no way to specify which
relationship when a table has multiple foreign keys to the same table.