### PR TITLE
Sf nested and/or fixes

### DIFF
--- a/src/util/options/include.js
+++ b/src/util/options/include.js
@@ -23,7 +23,7 @@ const notNull = array => _.filter(array, c => !_.isNil(c));
 
 const keysFromNode = node => {
   if (_.isArray(node)) {
-    return notNull(node.map(c => keysFromNode(c)));
+    return _.flatMap(notNull(node.map(c => keysFromNode(c))));
   }
 
   if (_.isString(node)) {

--- a/src/util/options/where.js
+++ b/src/util/options/where.js
@@ -20,8 +20,6 @@ const literalMap = {
   like: node => `%${node}%`,
   startsWith: node => `${node}%`,
   endsWith: node => `%${node}`,
-  and: node => mapNode(_.values(node)),
-  or: node => mapNode(_.values(node)),
 };
 
 const mapKey = key => {


### PR DESCRIPTION
Fixes issues when querying with and/or queries.

Flatted the set of arrays when mapping an array of nodes. Fixes a “item.split is not a function” error when mapping an and or or clause

Fixed issue where navigation property clauses are double escaped.  The parameters to the and/or clauses are already run through a call to mapNode.  Don’t it twice adds extra $’s to the properties.