### PR TITLE
Expand and bug fixes

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -110,6 +110,8 @@ class Implementation {
       [MAX]: () => options.max,
     };
 
+    console.log(options);
+
     const findAll = () => model.findAll(options).then(result => result.map(item => item.dataValues));
     const wrap = (value, meta) => {
       const result = {value};

--- a/src/database.js
+++ b/src/database.js
@@ -110,8 +110,6 @@ class Implementation {
       [MAX]: () => options.max,
     };
 
-    console.log(options);
-
     const findAll = () => model.findAll(options).then(result => result.map(item => item.dataValues));
     const wrap = (value, meta) => {
       const result = {value};

--- a/src/util/options/include.js
+++ b/src/util/options/include.js
@@ -75,6 +75,10 @@ const compileCheckList = params => {
     checklist.push(shouldIncludeByWhere);
   }
 
+  if (!params.constraints || params.constraints.expand) {
+    checklist.push(shouldIncludeByExpand);
+  }
+
   return checklist;
 };
 
@@ -109,6 +113,16 @@ const shouldIncludeBySelect = (model, relationship, params) => {
   }
 
   return relationshipApplies(model, relationship, select, item => item.split('.'));
+};
+
+const shouldIncludeByExpand = (model, relationship, params) => {
+  // nothing specified, so don't imply either way
+  const expand = params.args.expand;
+  if (expand === undefined) {
+    return undefined;
+  }
+
+  return relationshipApplies(model, relationship, expand , item => item.split('.'));
 };
 
 const shouldIncludeByOrderBy = (model, relationship, params) => {
@@ -231,6 +245,10 @@ const defineInclude = (model, relationship, params, path) => {
 
 // entry point for recursion so we can go down the rabbit hole
 const build = (model, params, path = []) => {
+
+
+  console.log(params);
+
   const appliedRelationships = _.filter(params.relationships,
     relationship => shouldIncludeRelationship(model, relationship, params));
 

--- a/src/util/options/include.js
+++ b/src/util/options/include.js
@@ -177,18 +177,19 @@ const defineAttributes = (related, relationship, params) => {
   const attributes = [];
   _.forEach(params.args.select, item => {
     const pieces = item.split('.');
+
     if (pieces.length < 2) {
       return;
     }
 
     const term = relationship.as ? relationship.as.replace('Id', '') : related.name;
 
-    if (pieces[pieces.length - 2] === term) {
+    if (pieces[pieces.length - 2] === pluralize(term) || pieces[pieces.length-2] === pluralize.singular(term)) {
       attributes.push(pieces[pieces.length - 1]);
     }
   });
 
-  return attributes.length === 0 ? undefined : attributes;
+  return attributes.length === 0 || attributes.includes('*') ? undefined : attributes;
 };
 
 const defineInclude = (model, relationship, params, path) => {

--- a/src/util/options/select.js
+++ b/src/util/options/select.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 export const buildSelect = (args, model) => {
-  if (!args.select) {
+  if (!args.select || args.select.includes('*')) {
     return undefined; // eslint-disable-line
   }
 


### PR DESCRIPTION
Added support for OData expand. 

Refactored the include methods to a single method builder since they were duplicated.  Fixed the inclusion of orderBy relationships.  

Allow select columns to work with singular or pluralized names like the relationship include already does.

Added support for $select=*