### PR TITLE
Fixed issues with many to many seeds

### DIFF
--- a/src/util/define_relationships.js
+++ b/src/util/define_relationships.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Sequelize from 'sequelize';
 import {logWarning} from 'node-bits';
-import {foreignKeyRelationshipName, foreignKeyName} from './foreign_key_name';
+import {foreignKeyRelationshipName, foreignKeyName, manyToManyTableName} from './relationship_names';
 
 const oneToOne = ({model, reference, rel}) => {
   const foreignKey = foreignKeyName(rel);
@@ -24,7 +24,7 @@ const oneToMany = ({model, reference, rel}) => {
 
 const manyToMany = ({sequelize, model, reference, rel, models}) => {
   // define join
-  const joinName = rel.through || `${model.name}_${reference.name}`;
+  const joinName = manyToManyTableName(rel);
   const sourceId = rel.source || `${model.name}Id`;
   const targetId = rel.target || `${reference.name}Id`;
   const joinModel = sequelize.define(joinName, {

--- a/src/util/options/include.js
+++ b/src/util/options/include.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import {MANY_TO_ONE, MANY_TO_MANY} from 'node-bits';
 import pluralize from 'pluralize';
-import {foreignKeyRelationshipName} from '../foreign_key_name';
+import {foreignKeyRelationshipName} from '../relationship_names';
 import {READ} from '../../constants';
 
 // boolean functions to define if the relationship makes it in

--- a/src/util/relationship_names.js
+++ b/src/util/relationship_names.js
@@ -13,3 +13,5 @@ export const foreignKeyName = rel => {
 
   return rel.as.endsWith('Id') ? rel.as : `${rel.as}Id`;
 };
+
+export const manyToManyTableName = rel => rel.through || `${rel.model}_${rel.references}`;


### PR DESCRIPTION
Many to many relationships create a seperate table, and are dependent on
both the model and references in the relationship.